### PR TITLE
Reuse shared PDO configuration in helpers

### DIFF
--- a/api/models.php
+++ b/api/models.php
@@ -9,12 +9,6 @@ if (!function_exists('pcslim_get_pdo')) {
             return $pdoInstance;
         }
 
-        if (isset($GLOBALS['pdo']) && $GLOBALS['pdo'] instanceof PDO) {
-            $pdoInstance = $GLOBALS['pdo'];
-            return $pdoInstance;
-        }
-
-        require_once __DIR__ . '/config.php';
         global $pdo, $DB_HOST, $DB_NAME, $DB_USER, $DB_PASS;
 
         if ($pdo instanceof PDO) {
@@ -22,8 +16,18 @@ if (!function_exists('pcslim_get_pdo')) {
             return $pdoInstance;
         }
 
+        if (!isset($DB_HOST, $DB_NAME, $DB_USER, $DB_PASS)) {
+            require_once __DIR__ . '/config.php';
+        }
+
+        // Config.php maakt normaliter de $pdo-connectie aan. Controleer opnieuw.
+        if ($pdo instanceof PDO) {
+            $pdoInstance = $pdo;
+            return $pdoInstance;
+        }
+
         if (isset($DB_HOST, $DB_NAME, $DB_USER, $DB_PASS)) {
-            $pdoInstance = new PDO(
+            $pdo = new PDO(
                 "mysql:host={$DB_HOST};dbname={$DB_NAME};charset=utf8mb4",
                 $DB_USER,
                 $DB_PASS,
@@ -32,6 +36,7 @@ if (!function_exists('pcslim_get_pdo')) {
                     PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
                 ]
             );
+            $pdoInstance = $pdo;
             return $pdoInstance;
         }
 

--- a/api/prices.php
+++ b/api/prices.php
@@ -16,23 +16,14 @@ if (!function_exists('get_prices')) {
     ];
 
     try {
-      require_once __DIR__ . '/config.php';
-      global $pdo, $DB_HOST, $DB_NAME, $DB_USER, $DB_PASS;
+      global $pdo;
 
       if (!($pdo instanceof PDO)) {
-        if (!isset($DB_HOST, $DB_NAME, $DB_USER, $DB_PASS)) {
-          return $defaults;
+        if (!function_exists('pcslim_get_pdo')) {
+          require_once __DIR__ . '/models.php';
         }
 
-        $pdo = new PDO(
-          "mysql:host={$DB_HOST};dbname={$DB_NAME};charset=utf8mb4",
-          $DB_USER,
-          $DB_PASS,
-          [
-            PDO::ATTR_ERRMODE => PDO::ERRMODE_EXCEPTION,
-            PDO::ATTR_DEFAULT_FETCH_MODE => PDO::FETCH_ASSOC,
-          ]
-        );
+        $pdo = pcslim_get_pdo();
       }
 
       $db = $pdo;


### PR DESCRIPTION
## Summary
- make `pcslim_get_pdo()` reuse the globally configured PDO instance before building a new connection
- update `get_prices()` to rely on the shared PDO helper so it no longer spins up its own connection

## Testing
- php -d error_reporting=E_ALL -d display_errors=1 -r '$GLOBALS["pdo"] = new PDO("sqlite::memory:"); require "api/models.php"; pcslim_get_pdo(); require "api/prices.php"; get_prices(); echo "ok\\n";'


------
https://chatgpt.com/codex/tasks/task_e_68dec807e4ac8328a8f15d7da009a8b0